### PR TITLE
Version 2.1 Build 2

### DIFF
--- a/SimpleQR/My Project/AssemblyInfo.vb
+++ b/SimpleQR/My Project/AssemblyInfo.vb
@@ -32,4 +32,4 @@ Imports System.Runtime.InteropServices
 ' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("2.1.1.17")>
+<Assembly: AssemblyFileVersion("2.1.2.18")>

--- a/SimpleQR/Program Modules/Check for Update Stuff.vb
+++ b/SimpleQR/Program Modules/Check for Update Stuff.vb
@@ -245,32 +245,25 @@ Namespace checkForUpdates
 
         Private Shared Function GetFullOSVersionString() As String
             Try
-                Dim intOSMajorVersion As Integer = Environment.OSVersion.Version.Major
-                Dim intOSMinorVersion As Integer = Environment.OSVersion.Version.Minor
-                Dim dblDOTNETVersion As Double = Double.Parse($"{Environment.Version.Major}.{Environment.Version.Minor}")
+                Dim osVersion As Version = Environment.OSVersion.Version
+                Dim intOSMajorVersion As Integer = osVersion.Major
+                Dim intOSMinorVersion As Integer = osVersion.Minor
+                Dim strDotNetVersion As String = $"{Environment.Version.Major}.{Environment.Version.Minor}"
                 Dim strOSName As String
 
-                If intOSMajorVersion = 5 And intOSMinorVersion = 0 Then
-                    strOSName = "Windows 2000"
-                ElseIf intOSMajorVersion = 5 And intOSMinorVersion = 1 Then
-                    strOSName = "Windows XP"
-                ElseIf intOSMajorVersion = 6 And intOSMinorVersion = 0 Then
-                    strOSName = "Windows Vista"
-                ElseIf intOSMajorVersion = 6 And intOSMinorVersion = 1 Then
+                If intOSMajorVersion = 6 And intOSMinorVersion = 1 Then
                     strOSName = "Windows 7"
                 ElseIf intOSMajorVersion = 6 And intOSMinorVersion = 2 Then
                     strOSName = "Windows 8"
                 ElseIf intOSMajorVersion = 6 And intOSMinorVersion = 3 Then
                     strOSName = "Windows 8.1"
-                ElseIf intOSMajorVersion = 10 Then
-                    strOSName = "Windows 10"
-                ElseIf intOSMajorVersion = 11 Then
-                    strOSName = "Windows 11"
+				ElseIf intOSMajorVersion = 10 Then
+                    strOSName = $"Windows {If(osVersion.Build >= 22000, "11", "10")}"
                 Else
                     strOSName = $"Windows NT {intOSMajorVersion}.{intOSMinorVersion}"
                 End If
 
-                Return $"{strOSName} {If(Environment.Is64BitOperatingSystem, "64", "32")}-bit (Microsoft .NET {dblDOTNETVersion})"
+                Return $"{strOSName} {If(Environment.Is64BitOperatingSystem, "64", "32")}-bit (Microsoft .NET {strDotNetVersion})"
             Catch ex As Exception
                 Try
                     Return $"Unknown Windows Operating System ({Environment.OSVersion.VersionString})"


### PR DESCRIPTION
Updated the GetFullOSVersionString() function to properly detect Windows 11 an removed detection of older EOL versions of Windows such as Windows XP and Windows Vista.